### PR TITLE
Add custom named `every`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 
 * fixes
+* add custom named `every` parameters
+* validate `every` and block params
 
 # 0.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem "puma"
 gem "sqlite3"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
-# gem "debug", ">= 1.0.0"
+gem "debug", ">= 1.0.0"

--- a/app/services/cron_table/server.rb
+++ b/app/services/cron_table/server.rb
@@ -1,78 +1,83 @@
-class CronTable::Server
-  SLEEP = 1.second..1.day
-  SLEEP_IDLE = 1.hour
+module CronTable
+  class Server
+    SLEEP = 1.second..1.day
+    SLEEP_IDLE = 1.hour
 
-  def initialize
-  end
+    def initialize
+    end
 
-  def sync!
-    crons = CronTable.all.clone
-    deleted = []
-    CronTable::Item.transaction do
-      CronTable::Item.lock.all.each do |cron|
-        if definition = crons.delete(cron.key)
-          cron.update(next_run_at: definition.next_run_at(Time.now)) if cron.next_run_at.nil?
-        elsif cron.next_run_at.present?
-          deleted << cron.key
+    def sync!
+      crons = CronTable.all.clone
+      deleted = []
+      Item.transaction do
+        Item.lock.all.each do |cron|
+          if definition = crons.delete(cron.key)
+            context = Context.new(last_run_at: nil)
+            cron.update(next_run_at: definition.next_run_at(context)) if cron.next_run_at.nil?
+          elsif cron.next_run_at.present?
+            deleted << cron.key
+          end
+        end
+        Item.where(key: deleted).update(next_run_at: nil)
+        crons.each do |key, definition|
+          context = Context.new(last_run_at: nil)
+          Item.create(key: key, next_run_at: definition.next_run_at(context))
         end
       end
-      CronTable::Item.where(key: deleted).update(next_run_at: nil)
-      crons.each do |key, definition|
-        CronTable::Item.create(key: key, next_run_at: definition.next_run_at(Time.now))
+    end
+
+    def run!
+      Item.connection_pool.with_connection do
+        sync!
+      end
+
+      @exit = false
+
+      Item.connection_pool.with_connection do
+        run_once!
+      end until exit?
+    end
+
+    def exit!
+      @exit = true
+      interrupt!
+    end
+
+    def exit?
+      @exit.present?
+    end
+
+    private
+
+    def run_once!
+      next_run_at = Item.minimum(:next_run_at) || SLEEP_IDLE.from_now
+      interruptible_sleep(next_run_at.to_f - Time.now.to_f)
+
+      Item.lock.where(next_run_at: ..Time.now).each do |cron|
+        process(cron)
       end
     end
-  end
 
-  def run!
-    CronTable::Item.connection_pool.with_connection do
-      sync!
+    def process(cron)
+      Rails.application.reloader.wrap do
+        definition = CronTable.all.fetch(cron.key)
+        definition.call
+
+        context = Context.new(last_run_at: cron.next_run_at)
+        cron.update(last_run_at: Time.now, next_run_at: definition.next_run_at(context))
+      end
+    rescue => e
+      cron.update(next_run_at: nil)
+      Rails.error.report(e, handled: true, severity: :error, context: { cron: cron.id })
     end
 
-    @exit = false
-
-    CronTable::Item.connection_pool.with_connection do
-      run_once!
-    end until exit?
-  end
-
-  def exit!
-    @exit = true
-    interrupt!
-  end
-
-  def exit?
-    @exit.present?
-  end
-
-  private
-
-  def run_once!
-    next_run_at = CronTable::Item.minimum(:next_run_at) || SLEEP_IDLE.from_now
-    interruptible_sleep(next_run_at.to_f - Time.now.to_f)
-
-    CronTable::Item.lock.where(next_run_at: ..Time.now).each do |cron|
-      process(cron)
+    def interruptible_sleep(seconds)
+      @sleep, @interrupt = IO.pipe
+      IO.select([@sleep], nil, nil, seconds.to_i.clamp(SLEEP))
     end
-  end
 
-  def process(cron)
-    Rails.application.reloader.wrap do
-      definition = CronTable.all.fetch(cron.key)
-      definition.call
-
-      cron.update(last_run_at: Time.now, next_run_at: definition.next_run_at(Time.now))
+    def interrupt!
+      @interrupt&.close
     end
-  rescue => e
-    cron.update(next_run_at: nil)
-    Rails.error.report(e, handled: true, severity: :error, context: { cron: cron.id })
-  end
-
-  def interruptible_sleep(seconds)
-    @sleep, @interrupt = IO.pipe
-    IO.select([@sleep], nil, nil, seconds.to_i.clamp(SLEEP))
-  end
-
-  def interrupt!
-    @interrupt&.close
   end
 end

--- a/cron-table.gemspec
+++ b/cron-table.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", "~> 7.0"
-  spec.add_development_dependency "mocha", "~> 1.0"
+  spec.add_development_dependency "mocha", "~> 2.0"
   spec.add_development_dependency "rufo", "~> 0.16"
 end

--- a/lib/cron-table.rb
+++ b/lib/cron-table.rb
@@ -2,11 +2,23 @@ require "cron-table/version"
 require "cron-table/engine"
 require "cron-table/definition"
 require "cron-table/schedule"
+require "cron-table/context"
 
 module CronTable
   mattr_accessor :attach_to_server, default: Rails.env.production?
 
   mattr_accessor :preload_dirs, default: ["app/jobs"]
+
+  mattr_accessor :every, default: {
+            midnight: ->(context) {
+              context.last_run_at.present? ?
+                (context.last_run_at + 1.day).midnight : Time.now.midnight
+            },
+            noon: ->(context) {
+              context.last_run_at.present? ?
+                (context.last_run_at + 1.day).noon : Time.now.noon
+            },
+          }
 
   @@all = nil
   def self.all

--- a/lib/cron-table/context.rb
+++ b/lib/cron-table/context.rb
@@ -1,0 +1,4 @@
+module CronTable
+  class Context < Struct.new(:last_run_at, keyword_init: true)
+  end
+end

--- a/lib/cron-table/definition.rb
+++ b/lib/cron-table/definition.rb
@@ -2,8 +2,13 @@ module CronTable
   class Definition < Struct.new(:key, :every, :block, keyword_init: true)
     delegate :call, to: :block
 
-    def next_run_at(now)
-      now + every
+    def next_run_at(context)
+      case every
+      when ActiveSupport::Duration
+        (context.last_run_at || Time.now) + every
+      when Symbol
+        CronTable.every.fetch(every).call(context)
+      end
     end
   end
 end

--- a/lib/cron-table/schedule.rb
+++ b/lib/cron-table/schedule.rb
@@ -14,6 +14,14 @@ module CronTable
       def message = "Provide a block to `crontable(..) { }` with code to execute"
     end
 
+    class InvalidEvery < ArgumentError
+      def initialize(every)
+        @every = every
+      end
+
+      def message = "Invalid every: #{every} "
+    end
+
     extend ActiveSupport::Concern
 
     included do |_base|
@@ -26,6 +34,7 @@ module CronTable
 
         block ||= -> { self.perform_later } if self.respond_to?(:perform_later)
         raise MissingBlockError if block.nil?
+        raise InvalidEvery.new(every) unless every.is_a?(ActiveSupport::Duration)
 
         CronTable.all[key] = Definition.new(key:, every:, block:)
 

--- a/test/cron_table/server_test.rb
+++ b/test/cron_table/server_test.rb
@@ -7,9 +7,5 @@ module CronTable
       Server.new.sync!
       assert_equal(["ExampleJob", "hourly"], Item.pluck(:key).sort)
     end
-
-    test "" do
-
-    end
   end
 end

--- a/test/cron_table/server_test.rb
+++ b/test/cron_table/server_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+module CronTable
+  class ServerTest < ActiveSupport::TestCase
+    test "creates valid cronjobs in database" do
+      assert_empty(Item.all)
+      Server.new.sync!
+      assert_equal(["ExampleJob", "hourly"], Item.pluck(:key).sort)
+    end
+
+    test "" do
+
+    end
+  end
+end

--- a/test/cron_table_test.rb
+++ b/test/cron_table_test.rb
@@ -26,4 +26,20 @@ class CronTableTest < ActiveSupport::TestCase
       CronTable.all[job.name].call
     end
   end
+
+  test "if every is not a valid period" do
+    job_class do |job|
+      assert_raises(CronTable::Schedule::InvalidEvery) do
+        job.class_eval { crontable(every: 1) {} }
+      end
+    end
+  end
+
+  test "if no block provided and cronjob is not an activejob" do
+    job_class do |job|
+      assert_raises(CronTable::Schedule::MissingBlockError) do
+        job.class_eval { crontable(every: 1.minute) }
+      end
+    end
+  end
 end

--- a/test/cron_table_test.rb
+++ b/test/cron_table_test.rb
@@ -30,7 +30,7 @@ class CronTableTest < ActiveSupport::TestCase
   test "if every is not a valid period" do
     job_class do |job|
       assert_raises(CronTable::Schedule::InvalidEvery) do
-        job.class_eval { crontable(every: 1) {} }
+        job.class_eval { crontable(every: 1) { } }
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
 require "mocha/minitest"
+require "minitest"
 
 class ActiveSupport::TestCase
   def job_class

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
 require "mocha/minitest"
-require "minitest"
 
 class ActiveSupport::TestCase
   def job_class


### PR DESCRIPTION
This:

- updates mocha to fix minitest 5.2 incompatibility
- adds tests for `every` and block parsing
- allows for defining custom named `every` blocks 